### PR TITLE
feat: expanded api firebase, add use-favorites and heart button, add favorites page and api favorites

### DIFF
--- a/src/app/store/store.ts
+++ b/src/app/store/store.ts
@@ -1,18 +1,20 @@
 import { configureStore } from '@reduxjs/toolkit';
 
 import { userReducer } from 'entities/user/slice';
-import { plantsApi } from 'shared/api';
+import { favoritesApi, plantsApi } from 'shared/api';
 
 import { signedInMiddleware } from './middleware';
 
 export const store = configureStore({
 	reducer: {
 		user: userReducer,
-		[plantsApi.reducerPath]: plantsApi.reducer
+		[plantsApi.reducerPath]: plantsApi.reducer,
+		[favoritesApi.reducerPath]: favoritesApi.reducer
 	},
 	middleware: (getDefaultMiddleware) =>
 		getDefaultMiddleware().concat([
 			plantsApi.middleware,
+			favoritesApi.middleware,
 			signedInMiddleware.middleware
 		])
 });

--- a/src/app/store/store.ts
+++ b/src/app/store/store.ts
@@ -1,7 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 
 import { userReducer } from 'entities/user/slice';
-import { favoritesApi, plantsApi } from 'shared/api';
+import { plantsApi } from 'shared/api';
 
 import { signedInMiddleware } from './middleware';
 
@@ -9,12 +9,10 @@ export const store = configureStore({
 	reducer: {
 		user: userReducer,
 		[plantsApi.reducerPath]: plantsApi.reducer,
-		[favoritesApi.reducerPath]: favoritesApi.reducer
 	},
 	middleware: (getDefaultMiddleware) =>
 		getDefaultMiddleware().concat([
 			plantsApi.middleware,
-			favoritesApi.middleware,
 			signedInMiddleware.middleware
 		])
 });

--- a/src/entities/favorite/favorite.ts
+++ b/src/entities/favorite/favorite.ts
@@ -1,0 +1,15 @@
+import { firebaseApi } from 'shared/api';
+
+export const favorite = {
+	async addFavorite(id: number): Promise<void> {
+		void await firebaseApi.addFavorite(id);
+	},
+
+	async removeFavorite(id: number): Promise<void> {
+		void await firebaseApi.removeFavorite(id);
+	},
+
+	async readFavorites(): Promise<number[]> {
+		return await firebaseApi.readFavorites();
+	}
+};

--- a/src/entities/favorite/index.ts
+++ b/src/entities/favorite/index.ts
@@ -1,0 +1,2 @@
+export { useFavorites } from './use-favorites';
+export { favorite } from './favorite';

--- a/src/entities/favorite/index.ts
+++ b/src/entities/favorite/index.ts
@@ -1,2 +1,3 @@
 export { useFavorites } from './use-favorites';
+export { useFavoritePlants } from './use-favorite-plants';
 export { favorite } from './favorite';

--- a/src/entities/favorite/use-favorite-plants.ts
+++ b/src/entities/favorite/use-favorite-plants.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { PlantType } from 'shared/config';
+import { usePlant } from 'shared/lib';
+
+import { useFavorites } from './use-favorites';
+
+export const useFavoritePlants = () => {
+	const { getPlants } = usePlant();
+	const { favoritesId, isFavoritesIdLoading } = useFavorites();
+	const [favoritePlants, setFavoritePlants] = useState<PlantType[]>([]);
+	const [isFavoritePlantsLoading, setIsFavoritePlantsLoading] = useState<boolean>(true);
+
+	const getFavoritePlants = useCallback(async (): Promise<void> => {
+		try {
+			setIsFavoritePlantsLoading(true);
+			setFavoritePlants(await getPlants(favoritesId));
+		} finally {
+			setIsFavoritePlantsLoading(false);
+		}
+	}, [favoritesId, getPlants]);
+
+	useEffect(() => {
+		if (favoritesId.length !== 0) {
+			void getFavoritePlants();
+		} else if (!isFavoritesIdLoading) {
+			setIsFavoritePlantsLoading(false)
+		}
+	}, [favoritesId, getFavoritePlants, isFavoritesIdLoading]);
+
+	return {
+		favoritePlants,
+		isFavoritePlantsLoading,
+		setFavoritePlants
+	};
+};

--- a/src/entities/favorite/use-favorites.ts
+++ b/src/entities/favorite/use-favorites.ts
@@ -7,26 +7,27 @@ import { favorite } from './favorite';
 
 export const useFavorites = () => {
 	const { authStatus } = useAuth();
-	const [favorites, setFavorites] = useState<number[]>([]);
-	const [isFavoritesLoading, setIsFavoritesLoading] = useState<boolean>(false);
+	const [favoritesId, setFavoritesId] = useState<number[]>([]);
+	const [isFavoritesIdLoading, setIsFavoritesIdLoading] = useState<boolean>(true);
 
 	const readFavorites = useCallback(async (): Promise<void> => {
-		setIsFavoritesLoading(true);
+		setIsFavoritesIdLoading(true);
 		const favoritesData = await favorite.readFavorites();
-		setFavorites(favoritesData);
-		setIsFavoritesLoading(false);
+		setFavoritesId(favoritesData);
+		setIsFavoritesIdLoading(false);
 	}, []);
 
 	useEffect(() => {
 		if (authStatus === AuthStatus.SignedIn) {
 			void readFavorites();
 		} else {
-			setFavorites([]);
+			setFavoritesId([]);
+			setIsFavoritesIdLoading(false);
 		}
 	}, [authStatus, readFavorites]);
 
 	return {
-		favorites,
-		isFavoritesLoading
+		favoritesId,
+		isFavoritesIdLoading
 	};
 };

--- a/src/entities/favorite/use-favorites.ts
+++ b/src/entities/favorite/use-favorites.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { useAuth } from 'entities/user';
+import { AuthStatus } from 'shared/config';
+
+import { favorite } from './favorite';
+
+export const useFavorites = () => {
+	const { authStatus } = useAuth();
+	const [favorites, setFavorites] = useState<number[]>([]);
+	const [isFavoritesLoading, setIsFavoritesLoading] = useState<boolean>(false);
+
+	const readFavorites = useCallback(async (): Promise<void> => {
+		setIsFavoritesLoading(true);
+		const favoritesData = await favorite.readFavorites();
+		setFavorites(favoritesData);
+		setIsFavoritesLoading(false);
+	}, []);
+
+	useEffect(() => {
+		if (authStatus === AuthStatus.SignedIn) {
+			void readFavorites();
+		} else {
+			setFavorites([]);
+		}
+	}, [authStatus, readFavorites]);
+
+	return {
+		favorites,
+		isFavoritesLoading
+	};
+};

--- a/src/entities/plant/ui/plant-card/ui.tsx
+++ b/src/entities/plant/ui/plant-card/ui.tsx
@@ -11,12 +11,12 @@ import './styles.css';
 
 interface Props {
 	plant: PlantType;
-	favorites: number[];
+	favoritesId: number[];
 	setFavoritePlants?: React.Dispatch<React.SetStateAction<PlantType[]>>;
 }
 
-function PlantCardMemo({ plant, favorites, setFavoritePlants }: Props) {
-	return (
+export const PlantCard = memo(({ plant, favoritesId, setFavoritePlants }: Props) =>
+	(
 		<div className='plant-card'>
 			<NavLink to={RouteName.PlANT_PAGE + '/' + plant.id}>
 				<PlantImage src={plant.image} alt={plant.image} />
@@ -31,12 +31,10 @@ function PlantCardMemo({ plant, favorites, setFavoritePlants }: Props) {
 							<div key={el}>{el}</div>
 						)}
 					</div>
-					<HeartButton id={plant.id} isFavorite={favorites.includes(plant.id)}
+					<HeartButton id={plant.id} isFavorite={favoritesId.includes(plant.id)}
 								 setFavoritePlants={setFavoritePlants} />
 				</div>
 			</div>
 		</div>
-	);
-}
-
-export const PlantCard = memo(PlantCardMemo)
+	)
+);

--- a/src/entities/plant/ui/plant-card/ui.tsx
+++ b/src/entities/plant/ui/plant-card/ui.tsx
@@ -1,6 +1,7 @@
+import React, { memo } from 'react';
 import { NavLink } from 'react-router-dom';
 
-import { Heart } from 'features/add-to-favorites';
+import { HeartButton } from 'features/add-to-favorites';
 import { PlantType, RouteName } from 'shared/config';
 import { getPlantShortInfo } from 'shared/lib';
 
@@ -10,9 +11,11 @@ import './styles.css';
 
 interface Props {
 	plant: PlantType;
+	favorites: number[];
+	setFavoritePlants?: React.Dispatch<React.SetStateAction<PlantType[]>>;
 }
 
-export function PlantCard({ plant }: Props) {
+function PlantCardMemo({ plant, favorites, setFavoritePlants }: Props) {
 	return (
 		<div className='plant-card'>
 			<NavLink to={RouteName.PlANT_PAGE + '/' + plant.id}>
@@ -28,9 +31,12 @@ export function PlantCard({ plant }: Props) {
 							<div key={el}>{el}</div>
 						)}
 					</div>
-					<Heart />
+					<HeartButton id={plant.id} isFavorite={favorites.includes(plant.id)}
+								 setFavoritePlants={setFavoritePlants} />
 				</div>
 			</div>
 		</div>
 	);
 }
+
+export const PlantCard = memo(PlantCardMemo)

--- a/src/entities/plant/ui/plant-details/ui.tsx
+++ b/src/entities/plant/ui/plant-details/ui.tsx
@@ -1,4 +1,4 @@
-import { Heart } from 'features/add-to-favorites';
+import { HeartButton } from 'features/add-to-favorites';
 import { PlantDetailsType } from 'shared/config';
 import { getPlantInfo } from 'shared/lib';
 
@@ -8,9 +8,10 @@ import './styles.css';
 
 interface Props {
 	plant: PlantDetailsType;
+	favorites: number[];
 }
 
-export function PlantDetails({ plant }: Props) {
+export function PlantDetails({ plant, favorites }: Props) {
 	return (
 		<div className='plant'>
 			<PlantImage src={plant.image} alt={plant.image} />
@@ -21,7 +22,7 @@ export function PlantDetails({ plant }: Props) {
 					{getPlantInfo(plant).map((el: string) =>
 						<div key={el}>{el}</div>
 					)}
-					<Heart />
+					<HeartButton id={plant.id} isFavorite={favorites.includes(plant.id)} />
 				</div>
 			</div>
 		</div>

--- a/src/entities/plant/ui/plant-details/ui.tsx
+++ b/src/entities/plant/ui/plant-details/ui.tsx
@@ -8,10 +8,10 @@ import './styles.css';
 
 interface Props {
 	plant: PlantDetailsType;
-	favorites: number[];
+	favoritesId: number[];
 }
 
-export function PlantDetails({ plant, favorites }: Props) {
+export function PlantDetails({ plant, favoritesId }: Props) {
 	return (
 		<div className='plant'>
 			<PlantImage src={plant.image} alt={plant.image} />
@@ -22,7 +22,7 @@ export function PlantDetails({ plant, favorites }: Props) {
 					{getPlantInfo(plant).map((el: string) =>
 						<div key={el}>{el}</div>
 					)}
-					<HeartButton id={plant.id} isFavorite={favorites.includes(plant.id)} />
+					<HeartButton id={plant.id} isFavorite={favoritesId.includes(plant.id)} />
 				</div>
 			</div>
 		</div>

--- a/src/entities/plant/ui/plant-image/ui.tsx
+++ b/src/entities/plant/ui/plant-image/ui.tsx
@@ -9,8 +9,8 @@ interface Props {
 	className?: string;
 }
 
-function PlantImageMemo({ src, alt, className }: Props) {
-	return (
+export const PlantImage = memo(({ src, alt, className }: Props) =>
+	(
 		<div className={`plant-img ${className} ${!src && 'plant-filter'}`}>
 			{src ?
 				<Image src={src} alt={alt} />
@@ -18,7 +18,5 @@ function PlantImageMemo({ src, alt, className }: Props) {
 				<Image className='filter' src='https://perenual.com/storage/image/missing_image.jpg' alt='Missing' />
 			}
 		</div>
-	);
-}
-
-export const PlantImage = memo(PlantImageMemo)
+	)
+);

--- a/src/entities/plant/ui/plant-image/ui.tsx
+++ b/src/entities/plant/ui/plant-image/ui.tsx
@@ -1,6 +1,7 @@
 import { Image } from 'shared/ui';
 
 import './styles.css';
+import { memo } from 'react';
 
 interface Props {
 	src: string;
@@ -8,7 +9,7 @@ interface Props {
 	className?: string;
 }
 
-export function PlantImage({ src, alt, className }: Props) {
+function PlantImageMemo({ src, alt, className }: Props) {
 	return (
 		<div className={`plant-img ${className} ${!src && 'plant-filter'}`}>
 			{src ?
@@ -19,3 +20,5 @@ export function PlantImage({ src, alt, className }: Props) {
 		</div>
 	);
 }
+
+export const PlantImage = memo(PlantImageMemo)

--- a/src/features/add-to-favorites/index.ts
+++ b/src/features/add-to-favorites/index.ts
@@ -1,1 +1,1 @@
-export { Heart } from './ui';
+export { HeartButton } from './ui';

--- a/src/features/add-to-favorites/ui.tsx
+++ b/src/features/add-to-favorites/ui.tsx
@@ -5,7 +5,6 @@ import { PiHeartFill, PiHeartLight } from 'react-icons/pi';
 import { favorite } from 'entities/favorite';
 import { useAuth } from 'entities/user';
 import { AuthStatus, PlantType, RouteName } from 'shared/config';
-import { usePlant } from 'shared/lib';
 
 import './styles.css';
 
@@ -19,7 +18,6 @@ function HeartButtonMemo({ id, isFavorite, setFavoritePlants }: Props) {
 	const { authStatus } = useAuth();
 	const [isAdded, setIsAdded] = useState<boolean>(isFavorite);
 	const navigate = useNavigate();
-	const { getPlantsById } = usePlant();
 
 	const handleClick = async (): Promise<void> => {
 		if (authStatus === AuthStatus.SignedIn) {
@@ -32,13 +30,6 @@ function HeartButtonMemo({ id, isFavorite, setFavoritePlants }: Props) {
 			} else {
 				void await favorite.addFavorite(id);
 				setIsAdded(true);
-				if (setFavoritePlants) {
-					const favoritePlant = await getPlantsById(id);
-					favoritePlant && setFavoritePlants(p => [
-						...p,
-						favoritePlant
-					]);
-				}
 			}
 		} else {
 			navigate(RouteName.REGISTRATION_PAGE);

--- a/src/features/add-to-favorites/ui.tsx
+++ b/src/features/add-to-favorites/ui.tsx
@@ -1,18 +1,48 @@
-import { useState } from 'react';
-
+import React, { memo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { PiHeartFill, PiHeartLight } from 'react-icons/pi';
+
+import { favorite } from 'entities/favorite';
+import { useAuth } from 'entities/user';
+import { AuthStatus, PlantType, RouteName } from 'shared/config';
+import { usePlant } from 'shared/lib';
 
 import './styles.css';
 
-//interface Props {
-//isAdded?: boolean;
-//}
+interface Props {
+	id: number;
+	isFavorite: boolean;
+	setFavoritePlants?: React.Dispatch<React.SetStateAction<PlantType[]>>;
+}
 
-export function Heart() {
-	// TODO: remake, add favoritesApi
-	const [isAdded, setIsAdded] = useState<boolean>(false);
-	const handleClick = () => {
-		setIsAdded(!isAdded);
+function HeartButtonMemo({ id, isFavorite, setFavoritePlants }: Props) {
+	const { authStatus } = useAuth();
+	const [isAdded, setIsAdded] = useState<boolean>(isFavorite);
+	const navigate = useNavigate();
+	const { getPlantsById } = usePlant();
+
+	const handleClick = async (): Promise<void> => {
+		if (authStatus === AuthStatus.SignedIn) {
+			if (isAdded) {
+				void await favorite.removeFavorite(id);
+				setIsAdded(false);
+				if (setFavoritePlants) {
+					setFavoritePlants(p => p.filter(el => el.id !== id));
+				}
+			} else {
+				void await favorite.addFavorite(id);
+				setIsAdded(true);
+				if (setFavoritePlants) {
+					const favoritePlant = await getPlantsById(id);
+					favoritePlant && setFavoritePlants(p => [
+						...p,
+						favoritePlant
+					]);
+				}
+			}
+		} else {
+			navigate(RouteName.REGISTRATION_PAGE);
+		}
 	};
 
 	return (
@@ -25,3 +55,5 @@ export function Heart() {
 		</button>
 	);
 }
+
+export const HeartButton = memo(HeartButtonMemo);

--- a/src/features/auth/auth/ui.tsx
+++ b/src/features/auth/auth/ui.tsx
@@ -21,21 +21,29 @@ export function AuthForm({ isLogin }: Props) {
 	const navigate = useNavigate();
 	const user = useAuth();
 
+	const emailValid = useCallback((): boolean =>
+		!!email.toLowerCase().match(emailRegular)
+	, [email]);
+
+	const passwordValid = useCallback((): boolean =>
+		password.length >= 8
+	, [password]);
+
 	const handleErrorEmail = useCallback((): void => {
-		if (email.toLowerCase().match(emailRegular)) {
+		if (emailValid()) {
 			setEmailError('');
 		} else {
 			setEmailError('Please enter a valid e-mail');
 		}
-	}, [email]);
+	}, [emailValid]);
 
 	const handleErrorPassword = useCallback((): void => {
-		if (password.length >= 8) {
+		if (passwordValid()) {
 			setPasswordError('');
 		} else {
 			setPasswordError('Passwords must have 8 characters or more');
 		}
-	}, [password.length]);
+	}, [passwordValid]);
 
 
 	const handleChangeEmail = useCallback((value: string): void => {
@@ -53,7 +61,7 @@ export function AuthForm({ isLogin }: Props) {
 			e.preventDefault();
 			handleErrorEmail();
 			handleErrorPassword();
-			if (email.toLowerCase().match(emailRegular) && password.length >= 8) {
+			if (emailValid() && passwordValid()) {
 				setIsLoading(true);
 				if (isLogin) {
 					await user.signIn(email, password);
@@ -71,7 +79,7 @@ export function AuthForm({ isLogin }: Props) {
 				setFormError('unknown_error');
 			}
 		}
-	}, [user, email, password, isLogin, handleErrorEmail, handleErrorPassword, navigate]);
+	}, [user, email, password, emailValid, passwordValid, isLogin, handleErrorEmail, handleErrorPassword, navigate]);
 
 	return (
 		<Form onSubmit={handleSubmit} className='auth-form' error={formError}>

--- a/src/pages/favorites/ui/index.tsx
+++ b/src/pages/favorites/ui/index.tsx
@@ -1,45 +1,18 @@
-import { useCallback, useEffect, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { CardList } from 'widgets/card-list';
-import { useFavorites } from 'entities/favorite';
+import { useFavoritePlants, useFavorites } from 'entities/favorite';
 import { Fallback, Loader } from 'shared/ui';
-import { PlantType } from 'shared/config';
-import { usePlant } from 'shared/lib';
 
 export function Favorites() {
-	const [favoritePlants, setFavoritePlants] = useState<PlantType[]>([]);
-	const [isLoading, setIsLoading] = useState<boolean>(true);
-	const { favorites, isFavoritesLoading } = useFavorites();
-	const { getPlantsById, filterPlants } = usePlant();
+	const { favoritesId, isFavoritesIdLoading } = useFavorites();
+	const { favoritePlants, isFavoritePlantsLoading, setFavoritePlants } = useFavoritePlants();
 
-	const getFavoritePlants = useCallback(async (): Promise<void> => {
-		try {
-			setIsLoading(true);
-			const favoritePlants = await Promise.all(
-				favorites.map(async (id: number) =>
-					await getPlantsById(id)
-				)
-			);
-			setFavoritePlants(filterPlants(favoritePlants));
-		} finally {
-			setIsLoading(false);
-		}
-	}, [favorites, getPlantsById, filterPlants]);
-
-	useEffect(() => {
-		if (favorites.length !== 0) {
-			void getFavoritePlants();
-		} else {
-			setIsLoading(false)
-		}
-	}, [favorites, getFavoritePlants]);
-
-	return isLoading || isFavoritesLoading ? (
+	return isFavoritePlantsLoading || isFavoritesIdLoading ? (
 		<Loader />
 	) : (
 		<ErrorBoundary FallbackComponent={Fallback}>
-			<CardList title='Favourite plants' data={favoritePlants} favorites={favorites}
+			<CardList title='Favourite plants' plants={favoritePlants} favoritesId={favoritesId}
 					  setFavoritePlants={setFavoritePlants}/>
 		</ErrorBoundary>
 	);

--- a/src/pages/favorites/ui/index.tsx
+++ b/src/pages/favorites/ui/index.tsx
@@ -1,7 +1,46 @@
-import React from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+
+import { CardList } from 'widgets/card-list';
+import { useFavorites } from 'entities/favorite';
+import { Fallback, Loader } from 'shared/ui';
+import { PlantType } from 'shared/config';
+import { usePlant } from 'shared/lib';
 
 export function Favorites() {
-	return (
-		<div>Favorites</div>
+	const [favoritePlants, setFavoritePlants] = useState<PlantType[]>([]);
+	const [isLoading, setIsLoading] = useState<boolean>(true);
+	const { favorites, isFavoritesLoading } = useFavorites();
+	const { getPlantsById, filterPlants } = usePlant();
+
+	const getFavoritePlants = useCallback(async (): Promise<void> => {
+		try {
+			setIsLoading(true);
+			const favoritePlants = await Promise.all(
+				favorites.map(async (id: number) =>
+					await getPlantsById(id)
+				)
+			);
+			setFavoritePlants(filterPlants(favoritePlants));
+		} finally {
+			setIsLoading(false);
+		}
+	}, [favorites, getPlantsById, filterPlants]);
+
+	useEffect(() => {
+		if (favorites.length !== 0) {
+			void getFavoritePlants();
+		} else {
+			setIsLoading(false)
+		}
+	}, [favorites, getFavoritePlants]);
+
+	return isLoading || isFavoritesLoading ? (
+		<Loader />
+	) : (
+		<ErrorBoundary FallbackComponent={Fallback}>
+			<CardList title='Favourite plants' data={favoritePlants} favorites={favorites}
+					  setFavoritePlants={setFavoritePlants}/>
+		</ErrorBoundary>
 	);
 }

--- a/src/pages/main/ui/index.tsx
+++ b/src/pages/main/ui/index.tsx
@@ -1,17 +1,19 @@
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { CardList } from 'widgets/card-list';
+import { useFavorites } from 'entities/favorite';
 import { useGetPlantsQuery } from 'shared/api';
 import { Fallback, Loader } from 'shared/ui';
 
 export function Main() {
 	const { data: plantsList = [], isLoading } = useGetPlantsQuery();
+	const { favorites, isFavoritesLoading } = useFavorites();
 
-	return isLoading ? (
+	return isLoading || isFavoritesLoading ? (
 		<Loader />
 	) : (
 		<ErrorBoundary FallbackComponent={Fallback}>
-			<CardList title='Indoor plants' data={plantsList} />
+			<CardList title='Indoor plants' data={plantsList} favorites={favorites} />
 		</ErrorBoundary>
 	);
 }

--- a/src/pages/main/ui/index.tsx
+++ b/src/pages/main/ui/index.tsx
@@ -7,13 +7,13 @@ import { Fallback, Loader } from 'shared/ui';
 
 export function Main() {
 	const { data: plantsList = [], isLoading } = useGetPlantsQuery();
-	const { favorites, isFavoritesLoading } = useFavorites();
+	const { favoritesId, isFavoritesIdLoading } = useFavorites();
 
-	return isLoading || isFavoritesLoading ? (
+	return isLoading || isFavoritesIdLoading ? (
 		<Loader />
 	) : (
 		<ErrorBoundary FallbackComponent={Fallback}>
-			<CardList title='Indoor plants' data={plantsList} favorites={favorites} />
+			<CardList title='Indoor plants' plants={plantsList} favoritesId={favoritesId} />
 		</ErrorBoundary>
 	);
 }

--- a/src/pages/plant/ui/index.tsx
+++ b/src/pages/plant/ui/index.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { PlantDetails } from 'entities/plant';
+import { useFavorites } from 'entities/favorite';
 import { useGetPlantsByIdQuery } from 'shared/api';
 import { Fallback, Loader } from 'shared/ui';
 
@@ -10,13 +11,14 @@ import './styles.css';
 export function Plant() {
 	const { id } = useParams();
 	const { data: plant, isLoading } = useGetPlantsByIdQuery(Number(id));
+	const { favorites, isFavoritesLoading } = useFavorites();
 
-	return isLoading ? (
+	return isLoading || isFavoritesLoading ? (
 		<Loader />
 	) : (
 		<ErrorBoundary FallbackComponent={Fallback}>
 			{plant ?
-				<PlantDetails plant={plant} />
+				<PlantDetails plant={plant} favorites={favorites}/>
 				:
 				<h2 className='nothing-found'>Nothing found</h2>
 			}

--- a/src/pages/plant/ui/index.tsx
+++ b/src/pages/plant/ui/index.tsx
@@ -11,14 +11,14 @@ import './styles.css';
 export function Plant() {
 	const { id } = useParams();
 	const { data: plant, isLoading } = useGetPlantsByIdQuery(Number(id));
-	const { favorites, isFavoritesLoading } = useFavorites();
+	const { favoritesId , isFavoritesIdLoading } = useFavorites();
 
-	return isLoading || isFavoritesLoading ? (
+	return isLoading || isFavoritesIdLoading ? (
 		<Loader />
 	) : (
 		<ErrorBoundary FallbackComponent={Fallback}>
 			{plant ?
-				<PlantDetails plant={plant} favorites={favorites}/>
+				<PlantDetails plant={plant} favoritesId={favoritesId}/>
 				:
 				<h2 className='nothing-found'>Nothing found</h2>
 			}

--- a/src/pages/search/ui/index.tsx
+++ b/src/pages/search/ui/index.tsx
@@ -10,13 +10,13 @@ export function Search() {
 	const [searchParams] = useSearchParams();
 	const query = searchParams.get('query') || '';
 	const { data: plantsList = [], isLoading } = useGetPlantsByNameQuery(query);
-	const { favorites, isFavoritesLoading } = useFavorites();
+	const { favoritesId, isFavoritesIdLoading } = useFavorites();
 
-	return isLoading || isFavoritesLoading ? (
+	return isLoading || isFavoritesIdLoading ? (
 		<Loader />
 	) : (
 		<ErrorBoundary FallbackComponent={Fallback}>
-			<CardList title='Search results' data={plantsList} favorites={favorites} />
+			<CardList title='Search results' plants={plantsList} favoritesId={favoritesId} />
 		</ErrorBoundary>
 
 	);

--- a/src/pages/search/ui/index.tsx
+++ b/src/pages/search/ui/index.tsx
@@ -2,6 +2,7 @@ import { useSearchParams } from 'react-router-dom';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { CardList } from 'widgets/card-list';
+import { useFavorites } from 'entities/favorite';
 import { useGetPlantsByNameQuery } from 'shared/api';
 import { Fallback, Loader } from 'shared/ui';
 
@@ -9,12 +10,13 @@ export function Search() {
 	const [searchParams] = useSearchParams();
 	const query = searchParams.get('query') || '';
 	const { data: plantsList = [], isLoading } = useGetPlantsByNameQuery(query);
+	const { favorites, isFavoritesLoading } = useFavorites();
 
-	return isLoading ? (
+	return isLoading || isFavoritesLoading ? (
 		<Loader />
 	) : (
 		<ErrorBoundary FallbackComponent={Fallback}>
-			<CardList title='Search results' data={plantsList} />
+			<CardList title='Search results' data={plantsList} favorites={favorites} />
 		</ErrorBoundary>
 
 	);

--- a/src/shared/api/favorites.ts
+++ b/src/shared/api/favorites.ts
@@ -1,23 +1,17 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-
-import { PlantType } from 'shared/config';
+import { PlantDetailsResponse, PlantType } from 'shared/config';
 import { transformPlantDetailsToPlant } from 'shared/lib';
 
-export const favoritesApi = createApi({
-	baseQuery: fetchBaseQuery({
-		method: 'GET',
-		baseUrl: process.env.REACT_APP_PLANTS_API_HOST
-	}),
-	reducerPath: 'favoritesApi',
-	endpoints: build => ({
-		getPlantsById: build.query<PlantType, number>({
-			query: id => ({
-				url: `/species/details/${id}`,
-				params: {
-					key: process.env.REACT_APP_PLANTS_API_KEY
+export const favoritesApi = {
+	async getPlantById(id : number) : Promise<PlantType | undefined> {
+		try {
+			const response = await fetch(`${process.env.REACT_APP_PLANTS_API_HOST}/species/details/${id}?key=${process.env.REACT_APP_PLANTS_API_KEY}`, {
+				method: 'GET',
+				headers: {
+					Accept: 'application/json'
 				}
-			}),
-			transformResponse: transformPlantDetailsToPlant
-		})
-	})
-});
+			})
+			const result = (await response.json()) as PlantDetailsResponse;
+			return transformPlantDetailsToPlant(result);
+		} catch (e) {}
+	}
+}

--- a/src/shared/api/favorites.ts
+++ b/src/shared/api/favorites.ts
@@ -1,0 +1,23 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+import { PlantType } from 'shared/config';
+import { transformPlantDetailsToPlant } from 'shared/lib';
+
+export const favoritesApi = createApi({
+	baseQuery: fetchBaseQuery({
+		method: 'GET',
+		baseUrl: process.env.REACT_APP_PLANTS_API_HOST
+	}),
+	reducerPath: 'favoritesApi',
+	endpoints: build => ({
+		getPlantsById: build.query<PlantType, number>({
+			query: id => ({
+				url: `/species/details/${id}`,
+				params: {
+					key: process.env.REACT_APP_PLANTS_API_KEY
+				}
+			}),
+			transformResponse: transformPlantDetailsToPlant
+		})
+	})
+});

--- a/src/shared/api/firebase.ts
+++ b/src/shared/api/firebase.ts
@@ -6,25 +6,66 @@ import {
 	User,
 	UserCredential
 } from 'firebase/auth';
+import { child, get, getDatabase, push, ref, set } from 'firebase/database';
 import { initializeApp } from 'firebase/app';
 
 import { FirebaseConfig } from 'shared/config';
 
 const app = initializeApp(FirebaseConfig);
 const auth = getAuth(app);
+const database = getDatabase(app, process.env.REACT_APP_FIREBASE_DB_URL);
 
 export const firebaseApi = {
 	async signUp(email: string, password: string): Promise<UserCredential> {
 		return await createUserWithEmailAndPassword(auth, email, password);
 	},
+
 	async signIn(email: string, password: string): Promise<UserCredential> {
 		return await signInWithEmailAndPassword(auth, email, password);
 	},
+
 	async signOut(): Promise<void> {
 		await signOut(auth);
 	},
+
 	async refresh(): Promise<User | null | undefined> {
 		await auth.authStateReady();
 		return auth.currentUser;
-	}
+	},
+
+	async addFavorite(plantId: number): Promise<void> {
+		const userId = auth.currentUser?.uid;
+		if (!userId) {
+			return;
+		}
+		const favoriteListRef = ref(database, 'favorites/' + userId);
+		const newFavoriteRef = push(favoriteListRef);
+		await set(newFavoriteRef, plantId);
+	},
+
+	async removeFavorite(plantId: number): Promise<void> {
+		const userId = auth.currentUser?.uid;
+		if (!userId) {
+			return;
+		}
+		const favoriteListRef = ref(database, 'favorites/' + userId);
+		const favorites = await this.readFavorites();
+		const newFavorites = favorites.filter(f => f !== plantId);
+		await set(favoriteListRef, newFavorites);
+	},
+
+	async readFavorites(): Promise<number[]> {
+		const userId = auth.currentUser?.uid;
+		if (!userId) {
+			return [];
+		}
+		const dbRef = ref(database);
+		const snapshot = await get(child(dbRef, 'favorites/' + userId));
+		if (snapshot.exists()) {
+			return Object.values(snapshot.val());
+		} else {
+			return [];
+		}
+	},
+
 };

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,2 +1,3 @@
 export { firebaseApi } from './firebase';
 export * from './plants';
+export * from './favorites';

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,5 +1,6 @@
 export { useAppSelector, useAppDispatch } from './use-app';
-export { transformPlants, transformPlantDetails, getPlantShortInfo, getPlantInfo } from './transform-plants';
+export { transformPlants, transformPlantDetails, transformPlantDetailsToPlant, getPlantShortInfo, getPlantInfo } from './transform-plants';
 export { useDebounce } from './use-debounce';
 export { AppError } from './app-error';
 export { getCurrentTheme, saveCurrentTheme, addThemeToHTML, removeThemeToHTML } from './theme';
+export { usePlant } from './use-plant'

--- a/src/shared/lib/transform-plants.ts
+++ b/src/shared/lib/transform-plants.ts
@@ -102,3 +102,14 @@ export const transformPlantDetails = (res: PlantDetailsResponse): PlantDetailsTy
 		description: res.description || 'Missing data',
 		image: getImage(res)
 	});
+
+export const transformPlantDetailsToPlant = (res: PlantDetailsResponse): PlantType =>
+	({
+		id: res.id,
+		name: res.scientific_name[0],
+		cycle: res.cycle || 'Missing data',
+		watering: res.watering || 'Missing data',
+		sunlight: getMissingDataInArray(res.sunlight),
+		image: getImage(res)
+	});
+

--- a/src/shared/lib/use-plant.ts
+++ b/src/shared/lib/use-plant.ts
@@ -1,19 +1,13 @@
 import { useCallback } from 'react';
 
 import { favoritesApi } from 'shared/api';
-import { useAppDispatch } from 'shared/lib';
 import { PlantType } from 'shared/config';
 
 export const usePlant = () => {
-	const dispatch = useAppDispatch();
 
-	const getPlantsById = useCallback(async (id: number): Promise<PlantType | undefined> => {
-		const { data } = await dispatch(favoritesApi.endpoints.getPlantsById.initiate(id));
-		if (!data) {
-			return data;
-		}
-		return data;
-	}, [dispatch]);
+	const getPlantById = useCallback(async (id: number): Promise<PlantType | undefined> =>
+			await favoritesApi.getPlantById(id)
+		, []);
 
 	const filterPlants = useCallback((plants: (PlantType | undefined)[]): PlantType[] => {
 		let data = [];
@@ -25,8 +19,16 @@ export const usePlant = () => {
 		return data;
 	}, []);
 
+	const getPlants = useCallback(async (favorites: number[]): Promise<PlantType[]> => {
+		const favoritePlants = await Promise.all(
+			favorites.map(async (id: number) =>
+				await getPlantById(id)
+			)
+		);
+		return filterPlants(favoritePlants);
+	}, [filterPlants, getPlantById]);
+
 	return {
-		getPlantsById,
-		filterPlants
+		getPlants
 	};
 };

--- a/src/shared/lib/use-plant.ts
+++ b/src/shared/lib/use-plant.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react';
+
+import { favoritesApi } from 'shared/api';
+import { useAppDispatch } from 'shared/lib';
+import { PlantType } from 'shared/config';
+
+export const usePlant = () => {
+	const dispatch = useAppDispatch();
+
+	const getPlantsById = useCallback(async (id: number): Promise<PlantType | undefined> => {
+		const { data } = await dispatch(favoritesApi.endpoints.getPlantsById.initiate(id));
+		if (!data) {
+			return data;
+		}
+		return data;
+	}, [dispatch]);
+
+	const filterPlants = useCallback((plants: (PlantType | undefined)[]): PlantType[] => {
+		let data = [];
+		for (let el of plants) {
+			if (el !== undefined) {
+				data.push(el);
+			}
+		}
+		return data;
+	}, []);
+
+	return {
+		getPlantsById,
+		filterPlants
+	};
+};

--- a/src/widgets/card-list/ui.tsx
+++ b/src/widgets/card-list/ui.tsx
@@ -7,12 +7,12 @@ import './styles.css';
 
 interface Props {
 	title: string;
-	data: PlantType[];
-	favorites: number[];
+	plants: PlantType[];
+	favoritesId: number[];
 	setFavoritePlants?: React.Dispatch<React.SetStateAction<PlantType[]>>;
 }
 
-export function CardList({ title, data, favorites, setFavoritePlants }: Props) {
+export function CardList({ title, plants, favoritesId, setFavoritePlants }: Props) {
 	return (
 		<div className='card-list'>
 			<div className='card-list__div'>
@@ -22,11 +22,11 @@ export function CardList({ title, data, favorites, setFavoritePlants }: Props) {
 				</div>
 			</div>
 			<section className='card-list__section'>
-				{data.map((item: PlantType) =>
-					<PlantCard key={item.id} plant={item} favorites={favorites} setFavoritePlants={setFavoritePlants} />
+				{plants.map((item: PlantType) =>
+					<PlantCard key={item.id} plant={item} favoritesId={favoritesId} setFavoritePlants={setFavoritePlants} />
 				)}
 			</section>
-			{data?.length === 0 &&
+			{plants?.length === 0 &&
 				<h2>Nothing found</h2>
 			}
 		</div>

--- a/src/widgets/card-list/ui.tsx
+++ b/src/widgets/card-list/ui.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { PlantCard } from 'entities/plant';
 import { PlantType } from 'shared/config';
 
@@ -6,9 +8,11 @@ import './styles.css';
 interface Props {
 	title: string;
 	data: PlantType[];
+	favorites: number[];
+	setFavoritePlants?: React.Dispatch<React.SetStateAction<PlantType[]>>;
 }
 
-export function CardList({ title, data }: Props) {
+export function CardList({ title, data, favorites, setFavoritePlants }: Props) {
 	return (
 		<div className='card-list'>
 			<div className='card-list__div'>
@@ -19,7 +23,7 @@ export function CardList({ title, data }: Props) {
 			</div>
 			<section className='card-list__section'>
 				{data.map((item: PlantType) =>
-					<PlantCard key={item.id} plant={item} />
+					<PlantCard key={item.id} plant={item} favorites={favorites} setFavoritePlants={setFavoritePlants} />
 				)}
 			</section>
 			{data?.length === 0 &&


### PR DESCRIPTION
### Что сделано

- Добавлены методы работы с избранными в `firebaseApi`
- Создана api` favoritesApi` и lib `transformPlantDetailsToPlant`
- Cоздан хук `usePlant` для получения избранных растений и фильтрации undefined
- Cоздана сущность `favorite` в качестве слоя разделяющего компоненты и api 
- Cоздан хук `useFavorites` для получения id избранных
- Создана фича `HeartButton` (если она используется на странице `Favorite`, то в неё пробрасывается `setFavoritePlants` для изменения массива избранных растений)
- Создана страница `Favorites` (этот компонент подгружает массив избранных растений)
- Использовано `memo` для оптимизации рендеринга `PlantCard`, `PlantImage`
- Рефакторинг фичи `AuthForm`

### Чек-лист

- [x] ПР имеет четкое **название**, короткое и описывающее его суть.
- [x] ПР имеет четкое **описание** того, что в рамках него было сделано.
- [x] Я провела **само-ревью** ПРа. Там нет кода, который я забыла удалить, случайно закоммитил и т.п.
- [x] ПР не содержит кода, который не соответствует цели ПРа.
- [x] ПР не содержит мерж конфликтов.